### PR TITLE
Add /transactions/{accountId}/visualise endpoint and refactor CSV export

### DIFF
--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
@@ -265,31 +265,14 @@ public final class TransactionHistoryController {
 
             Deque<Transaction> historyList = cache.get(accountId);
 
-            StringBuilder csv = new StringBuilder();
-            csv.append("transaction_id,timestamp,from_account,from_routing,to_account,to_routing,amount_cents\n");
-            for (Transaction t : historyList) {
-                Date ts = t.getTimestamp();
-                if (fromDate != null && (ts == null || ts.before(fromDate))) {
-                    continue;
-                }
-                if (toDate != null && (ts == null || !ts.before(toDate))) {
-                    continue;
-                }
-                csv.append(t.getTransactionId()).append(",");
-                csv.append(ts != null ? ts.toInstant().toString() : "").append(",");
-                csv.append(t.getFromAccountNum()).append(",");
-                csv.append(t.getFromRoutingNum()).append(",");
-                csv.append(t.getToAccountNum()).append(",");
-                csv.append(t.getToRoutingNum()).append(",");
-                csv.append(t.getAmount()).append("\n");
-            }
+            String csv = buildCsv(historyList, fromDate, toDate);
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.valueOf("text/csv"));
             headers.setContentDisposition(ContentDisposition.attachment()
                     .filename("transactions_" + accountId + ".csv").build());
 
-            return new ResponseEntity<>(csv.toString(), headers, HttpStatus.OK);
+            return new ResponseEntity<>(csv, headers, HttpStatus.OK);
         } catch (JWTVerificationException e) {
             LOGGER.error("Failed to export account transactions: not authorized");
             return new ResponseEntity<>("not authorized", HttpStatus.UNAUTHORIZED);
@@ -298,5 +281,187 @@ public final class TransactionHistoryController {
             return new ResponseEntity<>("cache error", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-}
+
+    /**
+     * Visualise transactions over time for the specified account.
+     *
+     * Returns a simple HTML page with a chart by default, or JSON if format=json.
+     * Supports the same 'from' and 'to' date filters as the CSV export.
+     */
+    @GetMapping("/transactions/{accountId}/visualise")
+    public ResponseEntity<?> visualiseTransactions(
+            @RequestHeader("Authorization") String bearerToken,
+            @PathVariable String accountId,
+            @RequestParam(value = "from", required = false) String from,
+            @RequestParam(value = "to", required = false) String to,
+            @RequestParam(value = "format", required = false, defaultValue = "html") String format) {
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken = bearerToken.split("Bearer ")[1];
+        }
+        try {
+            DecodedJWT jwt = verifier.verify(bearerToken);
+            if (!accountId.equals(jwt.getClaim("acct").asString())) {
+                LOGGER.error("Failed to visualise account transactions: not authorized");
+                return new ResponseEntity<>("not authorized", HttpStatus.UNAUTHORIZED);
+            }
+
+            Date fromDate = null;
+            Date toDate = null;
+            ZoneId zone = ZoneId.systemDefault();
+            if (from != null && !from.isEmpty()) {
+                try {
+                    LocalDate d = LocalDate.parse(from);
+                    fromDate = Date.from(d.atStartOfDay(zone).toInstant());
+                } catch (DateTimeParseException ex) {
+                    return new ResponseEntity<>("invalid 'from' date format, expected YYYY-MM-DD",
+                            HttpStatus.BAD_REQUEST);
+                }
+            }
+            if (to != null && !to.isEmpty()) {
+                try {
+                    LocalDate d = LocalDate.parse(to);
+                    // end of day inclusive
+                    toDate = Date.from(d.plusDays(1).atStartOfDay(zone).toInstant());
+                } catch (DateTimeParseException ex) {
+                    return new ResponseEntity<>("invalid 'to' date format, expected YYYY-MM-DD",
+                            HttpStatus.BAD_REQUEST);
+                }
+            }
+
+            Deque<Transaction> historyList = cache.get(accountId);
+            String csv = buildCsv(historyList, fromDate, toDate);
+
+            // Parse CSV and aggregate counts per day
+            java.util.LinkedHashMap<java.time.LocalDate, long[]> daily = new java.util.LinkedHashMap<>();
+            String[] lines = csv.split("\n");
+            for (int i = 1; i < lines.length; i++) { // skip header
+                String line = lines[i].trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+                String[] fields = line.split(",", -1);
+                if (fields.length < 7) {
+                    continue;
+                }
+                String ts = fields[1];
+                String amtStr = fields[6];
+                if (ts == null || ts.isEmpty()) {
+                    continue;
+                }
+                java.time.Instant instant = java.time.Instant.parse(ts);
+                java.time.LocalDate date = instant.atZone(zone).toLocalDate();
+                long amt = 0;
+                try {
+                    amt = Long.parseLong(amtStr);
+                } catch (NumberFormatException ignored) { }
+                long[] agg = daily.getOrDefault(date, new long[]{0L, 0L});
+                agg[0] += 1;        // count
+                agg[1] += amt;      // amount_cents
+                daily.put(date, agg);
+            }
+
+            if ("json".equalsIgnoreCase(format)) {
+                java.util.Map<String, Object> resp = new java.util.LinkedHashMap<>();
+                resp.put("accountId", accountId);
+                resp.put("from", from);
+                resp.put("to", to);
+                java.util.List<java.util.Map<String, Object>> points = new java.util.ArrayList<>();
+                long totalCount = 0;
+                long totalAmount = 0;
+                java.time.format.DateTimeFormatter df = java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+                for (java.util.Map.Entry<java.time.LocalDate, long[]> e : daily.entrySet()) {
+                    java.util.Map<String, Object> p = new java.util.LinkedHashMap<>();
+                    p.put("date", e.getKey().format(df));
+                    p.put("count", e.getValue()[0]);
+                    p.put("amount_cents", e.getValue()[1]);
+                    totalCount += e.getValue()[0];
+                    totalAmount += e.getValue()[1];
+                    points.add(p);
+                }
+                resp.put("points", points);
+                java.util.Map<String, Object> totals = new java.util.LinkedHashMap<>();
+                totals.put("count", totalCount);
+                totals.put("amount_cents", totalAmount);
+                resp.put("totals", totals);
+                return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(resp);
+            } else {
+                String html = buildHtmlDashboard(accountId, daily);
+                return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(html);
+            }
+        } catch (JWTVerificationException e) {
+            LOGGER.error("Failed to visualise account transactions: not authorized");
+            return new ResponseEntity<>("not authorized", HttpStatus.UNAUTHORIZED);
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            LOGGER.error("Cache error");
+            return new ResponseEntity<>("cache error", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Build CSV string from transactions with optional date filtering.
+     */
+    private String buildCsv(Deque<Transaction> historyList, Date fromDate, Date toDate) {
+        StringBuilder csv = new StringBuilder();
+        csv.append("transaction_id,timestamp,from_account,from_routing,to_account,to_routing,amount_cents\n");
+        for (Transaction t : historyList) {
+            Date ts = t.getTimestamp();
+            if (fromDate != null && (ts == null || ts.before(fromDate))) {
+                continue;
+            }
+            if (toDate != null && (ts == null || !ts.before(toDate))) {
+                continue;
+            }
+            csv.append(t.getTransactionId()).append(",");
+            csv.append(ts != null ? ts.toInstant().toString() : "").append(",");
+            csv.append(t.getFromAccountNum()).append(",");
+            csv.append(t.getFromRoutingNum()).append(",");
+            csv.append(t.getToAccountNum()).append(",");
+            csv.append(t.getToRoutingNum()).append(",");
+            csv.append(t.getAmount()).append("\n");
+        }
+        return csv.toString();
+    }
+
+    /**
+     * Build a simple HTML dashboard using Google Charts to show volume over time.
+     */
+    private String buildHtmlDashboard(String accountId, java.util.LinkedHashMap<java.time.LocalDate, long[]> daily) {
+        StringBuilder sb = new StringBuilder();
+        java.time.format.DateTimeFormatter df = java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+        sb.append("<!doctype html><html><head><meta charset=\"utf-8\">");
+        sb.append("<title>Transactions for ").append(accountId).append("</title>");
+        sb.append("<script type=\"text/javascript\" src=\"https://www.gstatic.com/charts/loader.js\"></script>");
+        sb.append("<script type=\"text/javascript\">");
+        sb.append("google.charts.load('current', {'packages':['corechart']});");
+        sb.append("google.charts.setOnLoadCallback(drawChart);");
+        sb.append("function drawChart(){");
+        sb.append("var data = new google.visualization.DataTable();");
+        sb.append("data.addColumn('string','Date');");
+        sb.append("data.addColumn('number','Transactions');");
+        sb.append("data.addColumn('number','Amount ($)');");
+        sb.append("data.addRows([");
+        boolean first = true;
+        for (java.util.Map.Entry<java.time.LocalDate, long[]> e : daily.entrySet()) {
+            if (!first) sb.append(",");
+            first = false;
+            double dollars = e.getValue()[1] / 100.0;
+            sb.append("[")
+              .append("'").append(e.getKey().format(df)).append("',")
+              .append(e.getValue()[0]).append(",")
+              .append(String.format(java.util.Locale.US, "%.2f", dollars))
+              .append("]");
+        }
+        sb.append("]);");
+        sb.append("var options = {title:'Transaction volume over time',legend:{position:'bottom'},height:400};");
+        sb.append("var chart = new google.visualization.LineChart(document.getElementById('chart'));");
+        sb.append("chart.draw(data, options);");
+        sb.append("}");
+        sb.append("</script>");
+        sb.append("</head><body>");
+        sb.append("<h2>Transactions for ").append(accountId).append("</h2>");
+        sb.append("<div id=\"chart\"></div>");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
This PR introduces a visualization endpoint that forks the existing CSV export flow to produce a simple dashboard or JSON summary of transaction volume over time.

Key changes
- Added GET /transactions/{accountId}/visualise in TransactionHistoryController.
  - Supports query params: from (YYYY-MM-DD), to (YYYY-MM-DD, inclusive), format (html|json, default html).
  - Verifies JWT and requires acct claim to match accountId (same auth as CSV export).
  - Returns HTML dashboard (default) rendered using Google Charts or JSON when format=json.
  - Aggregates transactions per day (count and total amount_cents).
  - Error handling: 400 for invalid date formats, 401 for unauthorized, 500 for cache errors.
- Extracted CSV building logic into buildCsv(...) and updated exportTransactionsCsv to use it.
- Added helper methods buildCsv(...) and buildHtmlDashboard(...) to keep concerns separated.

Usage examples
- HTML dashboard: GET /transactions/12345/visualise
- JSON output: GET /transactions/12345/visualise?format=json
- Date filtering: GET /transactions/12345/visualise?from=2025-01-01&to=2025-01-31

Implementation notes
- The HTML view uses Google Charts loader (external script) to plot transactions and amounts over time.
- The CSV parsing used to build the visualization reuses the same CSV format as the export to ensure consistency.

This change enables quick, lightweight visualization of per-account transaction history while keeping the original CSV export behavior intact.

---

> This pull request was co-created with Cosine Genie

Original Task: [finance-demo/8gke18kfax6i](https://cosine.sh/cosinedemo/finance-demo/task/8gke18kfax6i)
Author: Chloë Hawling
