### PR TITLE
Add CSV export endpoint for transaction history with optional date filters

### DIFF
--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/Transaction.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/Transaction.java
@@ -83,6 +83,11 @@ public final class Transaction {
     public Integer getAmount() {
         return amount;
     }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
     /**
      * String representation.
      *

--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
@@ -23,18 +23,27 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -178,7 +187,7 @@ public final class TransactionHistoryController {
                 LOGGER.error("Failed to retrieve account transactions: "
                     + "not authorized");
                 return new ResponseEntity<>("not authorized",
-                                                  HttpStatus.UNAUTHORIZED);
+                                              HttpStatus.UNAUTHORIZED);
             }
 
             // Load from cache
@@ -207,4 +216,128 @@ public final class TransactionHistoryController {
                                               HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    /**
+     * Export transactions for the specified account as CSV, with optional
+     * from/to date filters.
+     *
+     * Query params accept ISO-8601 timestamps (e.g. 2024-01-01T00:00:00Z),
+     * dates (e.g. 2024-01-01 assume start of day UTC), or epoch millis.
+     *
+     * @param bearerToken  HTTP request 'Authorization' header
+     * @param accountId    the account to export transactions for.
+     * @param from         optional start time filter
+     * @param to           optional end time filter
+     * @return             CSV content of filtered transactions.
+     */
+    @GetMapping(value = "/transactions/{accountId}/export")
+    public ResponseEntity<?> exportTransactionsCsv(
+            @RequestHeader("Authorization") String bearerToken,
+            @PathVariable String accountId,
+            @RequestParam(name = "from", required = false) String from,
+            @RequestParam(name = "to", required = false) String to) {
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken = bearerToken.split("Bearer ")[1];
+        }
+        try {
+            DecodedJWT jwt = verifier.verify(bearerToken);
+            if (!accountId.equals(jwt.getClaim("acct").asString())) {
+                LOGGER.error("Failed to export account transactions: not authorized");
+                return new ResponseEntity<>("not authorized", HttpStatus.UNAUTHORIZED);
+            }
+
+            Deque<Transaction> historyList = cache.get(accountId);
+
+            Instant fromInstant = parseInstantOrNull(from, true);
+            Instant toInstant = parseInstantOrNull(to, false);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("transactionId,fromAccountNum,fromRoutingNum,toAccountNum,toRoutingNum,amount,timestamp\n");
+
+            Iterator<Transaction> it = historyList.iterator();
+            while (it.hasNext()) {
+                Transaction t = it.next();
+                Instant ts = t.getTimestamp() != null ? t.getTimestamp().toInstant() : null;
+
+                boolean include = true;
+                if (fromInstant != null && ts != null) {
+                    include = include && !ts.isBefore(fromInstant);
+                }
+                if (toInstant != null && ts != null) {
+                    include = include && !ts.isAfter(toInstant);
+                }
+                // If timestamp is null, include only when no filters are set
+                if (ts == null && (fromInstant != null || toInstant != null)) {
+                    include = false;
+                }
+
+                if (include) {
+                    sb.append(t.getTransactionId()).append(",");
+                    sb.append(t.getFromAccountNum()).append(",");
+                    sb.append(t.getFromRoutingNum()).append(",");
+                    sb.append(t.getToAccountNum()).append(",");
+                    sb.append(t.getToRoutingNum()).append(",");
+                    sb.append(t.getAmount()).append(",");
+                    sb.append(ts != null ? ts.toString() : "").append("\n");
+                }
+            }
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(new MediaType("text", "csv", StandardCharsets.UTF_8));
+            headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"transactions.csv\"");
+
+            return new ResponseEntity<>(sb.toString(), headers, HttpStatus.OK);
+        } catch (JWTVerificationException e) {
+            LOGGER.error("Failed to export account transactions: not authorized");
+            return new ResponseEntity<>("not authorized", HttpStatus.UNAUTHORIZED);
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            LOGGER.error("Cache error");
+            return new ResponseEntity<>("cache error",
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (IllegalArgumentException e) {
+            LOGGER.error("Invalid date filter");
+            return new ResponseEntity<>("invalid date filter", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    /**
+     * Attempts to parse the provided string into an Instant. Supports:
+     * - ISO-8601 timestamp e.g. 2024-01-01T12:00:00Z
+     * - Date-only e.g. 2024-01-01 (assumes start/end of day UTC based on isStart)
+     * - Epoch millis e.g. 1696118400000
+     *
+     * Returns null if input is null or empty.
+     */
+    private Instant parseInstantOrNull(String input, boolean isStart) throws IllegalArgumentException {
+        if (input == null || input.trim().isEmpty()) {
+            return null;
+        }
+        String s = input.trim();
+        // Try epoch millis
+        try {
+            if (s.matches("^\\d{10,}$")) {
+                long millis = Long.parseLong(s);
+                return Instant.ofEpochMilli(millis);
+            }
+        } catch (NumberFormatException ignored) {
+        }
+        // Try ISO-8601 timestamp
+        try {
+            return Instant.parse(s);
+        } catch (DateTimeParseException ignored) {
+        }
+        // Try date-only
+        try {
+            LocalDate d = LocalDate.parse(s);
+            if (isStart) {
+                return d.atStartOfDay().toInstant(ZoneOffset.UTC);
+            } else {
+                return d.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).minusMillis(1);
+            }
+        } catch (DateTimeParseException ignored) {
+        }
+        throw new IllegalArgumentException("Unrecognized date format: " + input);
+    }
+}
 }


### PR DESCRIPTION
What changed

- Added a getter for timestamp in Transaction.java.
- Added a new endpoint in TransactionHistoryController: GET /transactions/{accountId}/export

What the new endpoint does

- Exports an account's transaction history as CSV with the following columns:
  transactionId, fromAccountNum, fromRoutingNum, toAccountNum, toRoutingNum, amount, timestamp
- Accepts optional query parameters `from` and `to` to filter transactions by timestamp.
- Authentication: verifies the bearer JWT and ensures the requested accountId matches the jwt claim "acct". Returns 401 when unauthorized.
- Error handling: returns 400 for invalid date filters, and 500 for cache-related errors.

Date filter parsing rules

- parseInstantOrNull helper supports multiple formats:
  - ISO-8601 timestamps (e.g. 2024-01-01T00:00:00Z)
  - Date-only values (e.g. 2024-01-01) — interpreted in UTC; `from` uses start of day, `to` uses end of day
  - Epoch milliseconds (e.g. 1696118400000)
- If a transaction's timestamp is null it will be included only when no from/to filters are set.

Response details

- Returns CSV content (text/csv; UTF-8) with Content-Disposition header to prompt download as transactions.csv.

Notes

- Small import adjustments and JSON/web-related headers were added to support CSV responses and date parsing.

---

> This pull request was co-created with Cosine Genie

Original Task: [finance-demo/5lq5k898w2h8](https://cosine.sh/cosinedemo/finance-demo/task/5lq5k898w2h8)
Author: James White
