### PR TITLE
Allow 4xx/5xx statuses to propagate for transaction endpoints (remove forced 200)

### DIFF
--- a/src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterController.java
+++ b/src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterController.java
@@ -127,10 +127,9 @@ public final class LedgerWriterController {
      * @param bearerToken  HTTP request 'Authorization' header
      * @param transaction  transaction to submit
      *
-     * @return  HTTP Status 200 if transaction was successfully submitted
+     * @return  HTTP Status 201 if transaction was successfully submitted
      */
     @PostMapping(value = "/transactions", consumes = "application/json")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<?> addTransaction(
             @RequestHeader("Authorization") String bearerToken,
             @RequestBody Transaction transaction) {

--- a/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithController.java
+++ b/src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithController.java
@@ -225,10 +225,9 @@ public final class LedgerMonolithController {
      * @param bearerToken  HTTP request 'Authorization' header
      * @param transaction  transaction to submit
      *
-     * @return  HTTP Status 200 if transaction was successfully submitted
+     * @return  HTTP Status 201 if transaction was successfully submitted
      */
     @PostMapping(value = "/transactions", consumes = "application/json")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<?> addTransaction(
             @RequestHeader("Authorization") String bearerToken,
             @RequestBody Transaction transaction) {


### PR DESCRIPTION
What I changed
- Removed the fixed @ResponseStatus(HttpStatus.OK) from the transaction POST endpoints in:
  - src/ledger/ledgerwriter/src/main/java/anthos/samples/bankofanthos/ledgerwriter/LedgerWriterController.java
  - src/ledgermonolith/src/main/java/anthos/samples/bankofanthos/ledgermonolith/LedgerMonolithController.java
- Updated Javadoc to indicate successful creation returns HTTP 201.

Why
- Previously the controller methods were annotated with @ResponseStatus(HttpStatus.OK), which forced a 200 response even when downstream operations failed. That caused the frontend and API callers to always receive HTTP 200 despite errors.
- By removing the fixed @ResponseStatus, the controllers now return the status carried by the ResponseEntity produced by the service/handler. This allows 4xx and 5xx statuses to propagate to callers correctly.

Effect
- Successful transaction submissions should return 201 Created (as documented).
- Failed payments/deposits will now surface their actual HTTP error codes (4xx/5xx) to the frontend and API clients instead of being masked as 200.

Notes
- No API surface changes beyond correcting the status behavior. Existing clients that relied on the previous incorrect 200 behavior should continue to work but will now receive appropriate error codes on failure.
- Recommend running integration tests or exercising the payment flows to confirm error propagation in your environment.

---

> This pull request was co-created with Cosine Genie

Original Task: [finance-demo/3onp86vbzdcx](https://cosine.sh/cosinedemo/finance-demo/task/3onp86vbzdcx)
Author: James White
