### PR TITLE
Add CSV export for account transaction history with optional date filters

### DIFF
--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
@@ -23,18 +23,27 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Deque;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -61,6 +70,7 @@ public final class TransactionHistoryController {
     private JWTVerifier verifier;
     private LedgerReader ledgerReader;
     private LoadingCache<String, Deque<Transaction>> cache;
+    private String localRoutingNum;
 
     /**
      * Constructor.
@@ -83,6 +93,7 @@ public final class TransactionHistoryController {
         GuavaCacheMetrics.monitor(meterRegistry, this.cache, "Guava");
         // Initialize transaction processor.
         this.ledgerReader = reader;
+        this.localRoutingNum = localRoutingNum;
         LOGGER.debug("Initialized transaction processor");
         this.ledgerReader.startWithCallback(transaction -> {
             final String fromId = transaction.getFromAccountNum();
@@ -206,5 +217,111 @@ public final class TransactionHistoryController {
             return new ResponseEntity<>("cache error",
                                               HttpStatus.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * Export a user's transaction history as CSV with optional date filters.
+     *
+     * The currently authenticated user must be allowed to access the account.
+     * @param bearerToken  HTTP request 'Authorization' header
+     * @param accountId    the account to get transactions for.
+     * @param fromDate     optional start date (inclusive) in ISO-8601 format (yyyy-MM-dd)
+     * @param toDate       optional end date (inclusive) in ISO-8601 format (yyyy-MM-dd)
+     * @return             CSV content for the account's transactions.
+     */
+    @GetMapping(value = "/transactions/{accountId}/export",
+            produces = "text/csv")
+    public ResponseEntity<String> exportTransactionsCsv(
+            @RequestHeader("Authorization") String bearerToken,
+            @PathVariable String accountId,
+            @RequestParam(name = "from", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            Date fromDate,
+            @RequestParam(name = "to", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            Date toDate) {
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken = bearerToken.split("Bearer ")[1];
+        }
+        try {
+            DecodedJWT jwt = verifier.verify(bearerToken);
+            if (!accountId.equals(jwt.getClaim("acct").asString())) {
+                LOGGER.error("Failed to export account transactions: "
+                    + "not authorized");
+                return new ResponseEntity<>("not authorized",
+                                              HttpStatus.UNAUTHORIZED);
+            }
+
+            // Make the end date inclusive by moving it to the end of the day.
+            if (toDate != null) {
+                Calendar calendar = Calendar.getInstance();
+                calendar.setTime(toDate);
+                calendar.add(Calendar.DATE, 1);
+                toDate = calendar.getTime();
+            }
+
+            List<Transaction> transactions =
+                dbRepo.findForAccountInRange(accountId,
+                                             localRoutingNum,
+                                             fromDate,
+                                             toDate);
+
+            String csv = toCsv(transactions);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.TEXT_PLAIN);
+            headers.set(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=\"transactions-" + accountId + ".csv\"");
+
+            return new ResponseEntity<>(csv, headers, HttpStatus.OK);
+        } catch (JWTVerificationException e) {
+            LOGGER.error("Failed to export account transactions: "
+                + "not authorized");
+            return new ResponseEntity<>("not authorized",
+                                              HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    /**
+     * Serialize transactions to CSV.
+     */
+    private String toCsv(List<Transaction> transactions) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("transactionId,timestamp,fromAccountNum,fromRoutingNum,")
+               .append("toAccountNum,toRoutingNum,amount\n");
+
+        DateFormat dateFormat =
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+
+        for (Transaction t : transactions) {
+            builder.append(t.getTransactionId()).append(",");
+            builder.append(dateFormat.format(t.getTimestamp())).append(",");
+            builder.append(escapeCsv(t.getFromAccountNum())).append(",");
+            builder.append(escapeCsv(t.getFromRoutingNum())).append(",");
+            builder.append(escapeCsv(t.getToAccountNum())).append(",");
+            builder.append(escapeCsv(t.getToRoutingNum())).append(",");
+            builder.append(t.getAmount());
+            builder.append("\n");
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * Escape a value for inclusion in a CSV file.
+     */
+    private String escapeCsv(String value) {
+        if (value == null) {
+            return "";
+        }
+        boolean hasSpecial =
+            value.contains(",") || value.contains("\"") || value.contains("\n")
+            || value.contains("\r");
+        if (!hasSpecial) {
+            return value;
+        }
+        String escaped = value.replace("\"", "\"\"");
+        return "\"" + escaped + "\"";
     }
 }

--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionRepository.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionRepository.java
@@ -1,5 +1,6 @@
 // Copyright 2020 Google LLC
 //
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,12 +15,14 @@
 
 package anthos.samples.bankofanthos.transactionhistory;
 
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -46,4 +49,16 @@ public interface TransactionRepository
     @Query("SELECT t FROM Transaction t "
         + " WHERE t.transactionId > ?1 ORDER BY t.transactionId ASC")
     List<Transaction> findLatest(long latestTransaction);
+
+    @Query("SELECT t FROM Transaction t "
+        + " WHERE ((t.fromAccountNum = :accountNum AND t.fromRoutingNum = :routingNum) "
+        + "    OR (t.toAccountNum = :accountNum AND t.toRoutingNum = :routingNum)) "
+        + "   AND (:fromDate IS NULL OR t.timestamp >= :fromDate) "
+        + "   AND (:toDate IS NULL OR t.timestamp <= :toDate) "
+        + " ORDER BY t.timestamp DESC")
+    List<Transaction> findForAccountInRange(
+        @Param("accountNum") String accountNum,
+        @Param("routingNum") String routingNum,
+        @Param("fromDate") Date fromDate,
+        @Param("toDate") Date toDate);
 }


### PR DESCRIPTION
Implements a new CSV export endpoint for a user’s transaction history with optional date filtering and adds necessary repository support.

What changed:
- TransactionHistoryController
  - Added GET /transactions/{accountId}/export producing text/csv.
  - Validates the Bearer token and ensures the authenticated user is authorized to access the specified account (jwt acct claim must match accountId).
  - Supports optional date filters via query parameters: from (ISO date yyyy-MM-dd) and to (ISO date yyyy-MM-dd). The to-date is made inclusive by advancing to the end of the day.
  - Fetches transactions using a new repository method in range and converts them to CSV with proper escaping and timestamp formatting.
  - Sets response headers for a file download (attachment; filename="transactions-<accountId>.csv").
  - Includes helper methods toCsv and escapeCsv to generate a well-formed CSV.

- TransactionRepository
  - Added findForAccountInRange(accountNum, routingNum, fromDate, toDate) with a query that selects transactions where the account is either the sender or recipient and applies optional fromDate/toDate filters. Returns results ordered by timestamp DESC.

How this solves the issue:
- Provides a straightforward CSV export for a user’s transaction history, with optional from/to date filters to narrow results.
- Ensures proper authorization by validating the JWT against the requested account.
- Produces CSV output with a clear header, timestamp formatting, and CSV escaping to handle special characters.


---

> This pull request was co-created with Cosine Genie

Original Task: [finance-demo/hplrtfe0r225](https://cosine.sh/cosinedemo/finance-demo/task/hplrtfe0r225)
Author: James White
