### PR TITLE
Propagate 4xx/5xx from backend calls to frontend/API; stop returning 200 on failures

### DIFF
--- a/src/frontend/frontend.py
+++ b/src/frontend/frontend.py
@@ -244,23 +244,21 @@ def create_app():
                                              _external=True,
                                              _scheme=app.config['SCHEME']))
 
-        except requests.exceptions.RequestException as err:
+        except HTTPError as err:
             app.logger.error('Error submitting payment: %s', str(err))
+            status = err.response.status_code if err.response is not None else 502
+            return make_response('Payment failed', status)
+        except RequestException as err:
+            app.logger.error('Error submitting payment: %s', str(err))
+            return make_response('Payment failed', 502)
         except UserWarning as warn:
             app.logger.error('Error submitting payment: %s', str(warn))
             msg = 'Payment failed: {}'.format(str(warn))
-            return redirect(url_for('home',
-                                    msg=msg,
-                                    _external=True,
-                                    _scheme=app.config['SCHEME']))
+            return make_response(msg, 400)
         except (ValueError, DecimalException) as num_err:
             app.logger.error('Error submitting payment: %s', str(num_err))
             msg = 'Payment failed: {} is not a valid number'.format(user_input)
-
-        return redirect(url_for('home',
-                                msg='Payment failed',
-                                _external=True,
-                                _scheme=app.config['SCHEME']))
+            return make_response(msg, 400)
 
     @app.route('/deposit', methods=['POST'])
     def deposit():
@@ -311,20 +309,21 @@ def create_app():
                                              _external=True,
                                              _scheme=app.config['SCHEME']))
 
-        except requests.exceptions.RequestException as err:
+        except HTTPError as err:
             app.logger.error('Error submitting deposit: %s', str(err))
+            status = err.response.status_code if err.response is not None else 502
+            return make_response('Deposit failed', status)
+        except RequestException as err:
+            app.logger.error('Error submitting deposit: %s', str(err))
+            return make_response('Deposit failed', 502)
         except UserWarning as warn:
             app.logger.error('Error submitting deposit: %s', str(warn))
             msg = 'Deposit failed: {}'.format(str(warn))
-            return redirect(url_for('home',
-                                    msg=msg,
-                                    _external=True,
-                                    _scheme=app.config['SCHEME']))
-
-        return redirect(url_for('home',
-                                msg='Deposit failed',
-                                _external=True,
-                                _scheme=app.config['SCHEME']))
+            return make_response(msg, 400)
+        except (ValueError, DecimalException) as num_err:
+            app.logger.error('Error submitting deposit: %s', str(num_err))
+            msg = 'Deposit failed: {} is not a valid number'.format(request.form['amount'])
+            return make_response(msg, 400)
 
     def _submit_transaction(transaction_data):
         app.logger.debug('Submitting transaction.')
@@ -335,10 +334,8 @@ def create_app():
                              data=jsonify(transaction_data).data,
                              headers=hed,
                              timeout=app.config['BACKEND_TIMEOUT'])
-        try:
-            resp.raise_for_status()  # Raise on HTTP Status code 4XX or 5XX
-        except requests.exceptions.HTTPError as http_request_err:
-            raise UserWarning(resp.text) from http_request_err
+        # Raise on HTTP Status code 4XX or 5XX so callers can propagate status.
+        resp.raise_for_status()
         # Short delay to allow the transaction to propagate to balancereader
         # and transaction-history
         sleep(0.25)


### PR DESCRIPTION
Fixes a bug where the app returned HTTP 200 even when payment/deposit requests failed by properly propagating 4xx/5xx statuses to callers. Key changes:
- Frontend error handling (payment and deposit):
  - Catch HTTPError and propagate the actual status code from the response (or 502 if unavailable) with a clear failure message.
  - Preserve 502 for generic RequestException cases.
  - Return 400 with descriptive messages for input-related/UserWarning failures instead of redirects.
- Backend transaction submission (_submit_transaction):
  - Removed the prior catch that hid HTTP errors;
  - Use resp.raise_for_status() to raise HTTPError on 4xx/5xx so these statuses propagate to the caller (frontend/API).
  - Retain a brief delay after submission for propagation.

Result:
Clients (frontend and API) will now receive appropriate 4xx/5xx responses when payment/deposit submissions fail, instead of always getting a 200 OK. Validation errors will still yield 400 with helpful messages.

---

> This pull request was co-created with Cosine Genie

Original Task: [finance-demo/bwv2x8ho3uzu](https://cosine.sh/cosinedemo/finance-demo/task/bwv2x8ho3uzu)
Author: James White
