### PR TITLE
Implement CSV export for user transaction history with optional date filters and authorization checks

### DIFF
--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/Transaction.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/Transaction.java
@@ -83,6 +83,11 @@ public final class Transaction {
     public Integer getAmount() {
         return amount;
     }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
     /**
      * String representation.
      *

--- a/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
+++ b/src/ledger/transactionhistory/src/main/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryController.java
@@ -23,18 +23,26 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -198,6 +206,121 @@ public final class TransactionHistoryController {
                     historyList, HttpStatus.OK);
         } catch (JWTVerificationException e) {
             LOGGER.error("Failed to retrieve account transactions: "
+                + "not authorized");
+            return new ResponseEntity<>("not authorized",
+                                              HttpStatus.UNAUTHORIZED);
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            LOGGER.error("Cache error");
+            return new ResponseEntity<>("cache error",
+                                              HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Return the transaction history for the specified account as CSV.
+     *
+     * The currently authenticated user must be allowed to access the account.
+     * Optional fromDate/toDate filters can be provided as ISO dates (yyyy-MM-dd).
+     * @param bearerToken  HTTP request 'Authorization' header
+     * @param accountId    the account to get transactions for.
+     * @param fromDate     optional start date (inclusive), ISO format yyyy-MM-dd
+     * @param toDate       optional end date (inclusive), ISO format yyyy-MM-dd
+     * @return             CSV string of transactions for this account.
+     */
+    @GetMapping(value = "/transactions/{accountId}/csv",
+                produces = "text/csv")
+    public ResponseEntity<?> exportTransactionsCsv(
+            @RequestHeader("Authorization") String bearerToken,
+            @PathVariable String accountId,
+            @RequestParam(name = "fromDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate fromDate,
+            @RequestParam(name = "toDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate toDate) {
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken = bearerToken.split("Bearer ")[1];
+        }
+        try {
+            DecodedJWT jwt = verifier.verify(bearerToken);
+            // Check that the authenticated user can access this account.
+            if (!accountId.equals(jwt.getClaim("acct").asString())) {
+                LOGGER.error("Failed to retrieve account transactions CSV: "
+                    + "not authorized");
+                return new ResponseEntity<>("not authorized",
+                                                  HttpStatus.UNAUTHORIZED);
+            }
+
+            Deque<Transaction> historyList = cache.get(accountId);
+
+            LocalDate from = fromDate;
+            LocalDate to = toDate;
+            ZoneId zoneId = ZoneId.systemDefault();
+
+            Collection<Transaction> filtered = historyList.stream()
+                    .filter(t -> {
+                        if (from == null && to == null) {
+                            return true;
+                        }
+                        if (t.getTimestamp() == null) {
+                            return false;
+                        }
+                        LocalDate txDate = t.getTimestamp()
+                                .toInstant()
+                                .atZone(zoneId)
+                                .toLocalDate();
+                        if (from != null && txDate.isBefore(from)) {
+                            return false;
+                        }
+                        if (to != null && txDate.isAfter(to)) {
+                            return false;
+                        }
+                        return true;
+                    })
+                    .collect(Collectors.toList());
+
+            // Set artificial extra latency.
+            LOGGER.debug("Setting artificial latency");
+            if (extraLatencyMillis != null) {
+                try {
+                    Thread.sleep(extraLatencyMillis);
+                } catch (InterruptedException e) {
+                    // Fake latency interrupted. Continue.
+                }
+            }
+
+            SimpleDateFormat formatter =
+                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+            StringBuilder csvBuilder = new StringBuilder();
+            csvBuilder.append("transactionId,fromAccountNum,fromRoutingNum,")
+                    .append("toAccountNum,toRoutingNum,amount,timestamp\n");
+
+            for (Transaction t : filtered) {
+                String timestampString = "";
+                if (t.getTimestamp() != null) {
+                    timestampString = formatter.format(t.getTimestamp());
+                }
+                csvBuilder.append(t.getTransactionId()).append(',')
+                        .append(t.getFromAccountNum()).append(',')
+                        .append(t.getFromRoutingNum()).append(',')
+                        .append(t.getToAccountNum()).append(',')
+                        .append(t.getToRoutingNum()).append(',')
+                        .append(t.getAmount()).append(',')
+                        .append(timestampString)
+                        .append('\n');
+            }
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType("text/csv"));
+            headers.set(HttpHeaders.CONTENT_DISPOSITION,
+                    "attachment; filename=\"transactions.csv\"");
+
+            return new ResponseEntity<>(csvBuilder.toString(),
+                    headers,
+                    HttpStatus.OK);
+        } catch (JWTVerificationException e) {
+            LOGGER.error("Failed to retrieve account transactions CSV: "
                 + "not authorized");
             return new ResponseEntity<>("not authorized",
                                               HttpStatus.UNAUTHORIZED);

--- a/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryControllerTest.java
+++ b/src/ledger/transactionhistory/src/test/java/anthos/samples/bankofanthos/transactionhistory/TransactionHistoryControllerTest.java
@@ -31,6 +31,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.lang.Nullable;
 import io.micrometer.stackdriver.StackdriverConfig;
 import io.micrometer.stackdriver.StackdriverMeterRegistry;
+import java.time.LocalDate;
 import java.util.Deque;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -213,6 +214,74 @@ class TransactionHistoryControllerTest {
         // When
         final ResponseEntity actualResult = transactionHistoryController
             .getTransactions(BEARER_TOKEN, AUTHED_ACCOUNT_NUM);
+
+        // Then
+        assertNotNull(actualResult);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, actualResult.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Given the user is authenticated for the account, export CSV with HTTP Status 200")
+    void exportTransactionsCsvSucceedsWhenAccountMatchesAuthenticatedUser() throws Exception {
+        // Given
+        when(verifier.verify(TOKEN)).thenReturn(jwt);
+        when(jwt.getClaim(JWT_ACCOUNT_KEY)).thenReturn(claim);
+        when(claim.asString()).thenReturn(AUTHED_ACCOUNT_NUM);
+        when(cache.get(AUTHED_ACCOUNT_NUM)).thenReturn(transactions);
+
+        // When
+        final ResponseEntity actualResult = transactionHistoryController
+            .exportTransactionsCsv(BEARER_TOKEN, AUTHED_ACCOUNT_NUM, null, null);
+
+        // Then
+        assertNotNull(actualResult);
+        assertEquals(HttpStatus.OK, actualResult.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Given the user is authenticated but cannot access the account for CSV, return 401")
+    void exportTransactionsCsvFailsWhenAccountDoesNotMatchAuthenticatedUser() {
+        // Given
+        when(verifier.verify(TOKEN)).thenReturn(jwt);
+        when(jwt.getClaim(JWT_ACCOUNT_KEY)).thenReturn(claim);
+        when(claim.asString()).thenReturn(AUTHED_ACCOUNT_NUM);
+
+        // When
+        final ResponseEntity actualResult = transactionHistoryController
+            .exportTransactionsCsv(BEARER_TOKEN, NON_AUTHED_ACCOUNT_NUM, null, null);
+
+        // Then
+        assertNotNull(actualResult);
+        assertEquals(HttpStatus.UNAUTHORIZED, actualResult.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Given the user is not authenticated for CSV, return 401")
+    void exportTransactionsCsvFailsWhenUserNotAuthenticated() {
+        // Given
+        when(verifier.verify(TOKEN)).thenThrow(JWTVerificationException.class);
+
+        // When
+        final ResponseEntity actualResult = transactionHistoryController
+            .exportTransactionsCsv(BEARER_TOKEN, AUTHED_ACCOUNT_NUM, null, null);
+
+        // Then
+        assertNotNull(actualResult);
+        assertEquals(HttpStatus.UNAUTHORIZED, actualResult.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Given the cache throws an error for an authenticated user for CSV, return 500")
+    void exportTransactionsCsvFailsWhenCacheThrowsError() throws Exception {
+        // Given
+        when(verifier.verify(TOKEN)).thenReturn(jwt);
+        when(jwt.getClaim(JWT_ACCOUNT_KEY)).thenReturn(claim);
+        when(claim.asString()).thenReturn(AUTHED_ACCOUNT_NUM);
+        when(cache.get(AUTHED_ACCOUNT_NUM)).thenThrow(ExecutionException.class);
+
+        // When
+        final ResponseEntity actualResult = transactionHistoryController
+            .exportTransactionsCsv(BEARER_TOKEN, AUTHED_ACCOUNT_NUM, null, null);
 
         // Then
         assertNotNull(actualResult);


### PR DESCRIPTION
Adds a new CSV export endpoint for a user's transaction history with optional date range filters, and updates the Transaction model to support timestamp export.

Summary of changes:
- Transaction model: added getTimestamp() to expose the timestamp needed for CSV export.
- TransactionHistoryController:
  - Introduced exportTransactionsCsv endpoint at /transactions/{accountId}/csv that produces text/csv.
  - Accepts optional fromDate and toDate query parameters in ISO yyyy-MM-dd format to filter transactions by timestamp (inclusive).
  - Validates the Authorization bearer token and ensures the authenticated user is allowed to access the requested account; returns 401 if not authorized.
  - Retrieves transaction history from cache, applies date range filtering, and formats timestamps using a precise pattern (yyyy-MM-dd'T'HH:mm:ssXXX).
  - Constructs a CSV with header: transactionId,fromAccountNum,fromRoutingNum,toAccountNum,toRoutingNum,amount,timestamp and returns it as an attachment with proper Content-Type and Content-Disposition headers.
  - Maintains existing error handling for authentication failures (401) and cache errors (500).

Tests:
- Updated TransactionHistoryControllerTest to cover:
  - Successful CSV export when the account matches the authenticated user.
  - 401 unauthorized when the authenticated user cannot access the account.
  - 401 when the user is not authenticated.
  - 500 cache error scenario.

This change enables clients to export a user’s transaction history as CSV with optional date filtering and proper authorization checks.

---

> This pull request was co-created with Cosine Genie

Original Task: [finance-demo/by2xzk4ip0bj](https://cosine.sh/cosinedemo/finance-demo/task/by2xzk4ip0bj)
Author: James White
