### PR TITLE
Return HTTP 502 on failed payment and deposit requests

### DIFF
--- a/src/frontend/frontend.py
+++ b/src/frontend/frontend.py
@@ -246,6 +246,7 @@ def create_app():
 
         except requests.exceptions.RequestException as err:
             app.logger.error('Error submitting payment: %s', str(err))
+            return abort(502)
         except UserWarning as warn:
             app.logger.error('Error submitting payment: %s', str(warn))
             msg = 'Payment failed: {}'.format(str(warn))
@@ -313,6 +314,7 @@ def create_app():
 
         except requests.exceptions.RequestException as err:
             app.logger.error('Error submitting deposit: %s', str(err))
+            return abort(502)
         except UserWarning as warn:
             app.logger.error('Error submitting deposit: %s', str(warn))
             msg = 'Deposit failed: {}'.format(str(warn))


### PR DESCRIPTION
Fixes a bug where the app returned HTTP 200 even when upstream payment and deposit requests failed. The changes add a 502 Bad Gateway response when a requests.exceptions.RequestException occurs during payment or deposit submissions, ensuring clients receive the correct error status. The existing error logging and UserWarning handling remain unchanged. Specifically, in src/frontend/frontend.py, a return abort(502) was added in both the payment() and deposit() exception handlers for requests.exceptions.RequestException.

---

> This pull request was co-created with Cosine Genie

Original Task: [finance-demo/0cf2qob87edr](https://cosine.sh/cosinedemo/finance-demo/task/0cf2qob87edr)
Author: James White
