### PR TITLE
Add pluggable notifications service with Console/SMTP providers and wire to user flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ The following button opens up an interactive tutorial showing how to deploy Bank
 - [Workload Identity](/docs/workload-identity.md) to learn how to set-up Workload Identity.
 - [CI/CD pipeline](/docs/ci-cd-pipeline.md) to learn details about and how to set-up the CI/CD pipeline.
 - [Troubleshooting](/docs/troubleshooting.md) to learn how to resolve common problems.
+- [User service notifications](/src/accounts/userservice/README.md#notifications-provider-configuration)
+  for details on configuring and switching the email notification provider
+  (console vs SMTP).
 
 ## Demos featuring Bank of Anthos
 - [Tutorial: Explore Anthos (Google Cloud docs)](https://cloud.google.com/anthos/docs/tutorials/explore-anthos)

--- a/src/accounts/userservice/README.md
+++ b/src/accounts/userservice/README.md
@@ -37,6 +37,37 @@ Implemented in Python with Flask.
   - `ACCOUNTS_DB_URI`
     - the complete URI for the `accounts-db` database
 
+#### Notifications provider configuration
+
+User-facing email notifications (welcome, password reset, etc.) are sent
+through a simple notifications service with a pluggable provider. The
+provider is selected at runtime via environment variables.
+
+- `NOTIFICATIONS_PROVIDER`
+  - which provider implementation to use
+  - supported values:
+    - `console` (default): log notification events only
+    - `smtp`: send real emails via SMTP
+
+When `NOTIFICATIONS_PROVIDER=smtp`, the following variables are used:
+
+- `SMTP_HOST`
+  - hostname of the SMTP server (required)
+- `SMTP_PORT`
+  - port of the SMTP server (default: `587`)
+- `SMTP_USERNAME`
+  - SMTP username (optional; if not set, authentication is skipped)
+- `SMTP_PASSWORD`
+  - SMTP password (optional; only used when `SMTP_USERNAME` is set)
+- `SMTP_USE_TLS`
+  - whether to use STARTTLS for SMTP connections (`true`/`false`, default: `true`)
+- `SMTP_FROM_ADDRESS`
+  - email address used for the `From:` header (required)
+
+> To switch providers, update `NOTIFICATIONS_PROVIDER` on the
+> `userservice` Deployment (for example from `console` to `smtp`) and
+> redeploy. No frontend changes are required.
+
 ### Kubernetes Resources
 
 - [deployments/userservice](/kubernetes-manifests/userservice.yaml)

--- a/src/accounts/userservice/notifications.py
+++ b/src/accounts/userservice/notifications.py
@@ -1,0 +1,201 @@
+# Copyright 2024
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Notification service and providers used by userservice.
+
+This module defines a simple abstraction for sending user-facing
+notifications (e.g. welcome and password reset emails) with pluggable
+providers. The concrete provider is selected at runtime via
+environment variables.
+"""
+
+import os
+import smtplib
+from abc import ABC, abstractmethod
+from email.message import EmailMessage
+
+
+class NotificationProvider(ABC):
+    """Abstract base class for notification providers."""
+
+    @abstractmethod
+    def send_welcome_email(self, recipient, full_name):
+        """Send a welcome email to the given recipient."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def send_password_reset_email(self, recipient, reset_link):
+        """Send a password reset email to the given recipient."""
+        raise NotImplementedError
+
+
+class ConsoleNotificationProvider(NotificationProvider):
+    """Notification provider that only logs messages."""
+
+    def __init__(self, logger):
+        self._logger = logger
+
+    def send_welcome_email(self, recipient, full_name):
+        self._logger.info(
+            "ConsoleNotificationProvider: welcome email to %s (%s)",
+            recipient,
+            full_name,
+        )
+
+    def send_password_reset_email(self, recipient, reset_link):
+        self._logger.info(
+            "ConsoleNotificationProvider: password reset email to %s with link %s",
+            recipient,
+            reset_link,
+        )
+
+
+class SmtpNotificationProvider(NotificationProvider):
+    """Notification provider that sends emails using SMTP."""
+
+    def __init__(self, host, port, username, password, use_tls, from_address, logger):
+        self._host = host
+        self._port = port
+        self._username = username
+        self._password = password
+        self._use_tls = use_tls
+        self._from_address = from_address
+        self._logger = logger
+
+    @classmethod
+    def from_env(cls, logger):
+        """Create an SMTP provider instance from environment variables."""
+        host = os.getenv("SMTP_HOST")
+        from_address = os.getenv("SMTP_FROM_ADDRESS")
+
+        if not host:
+            raise ValueError("SMTP_HOST environment variable must be set for SMTP provider")
+        if not from_address:
+            raise ValueError(
+                "SMTP_FROM_ADDRESS environment variable must be set for SMTP provider"
+            )
+
+        port = int(os.getenv("SMTP_PORT", "587"))
+        username = os.getenv("SMTP_USERNAME")
+        password = os.getenv("SMTP_PASSWORD")
+        use_tls = os.getenv("SMTP_USE_TLS", "true").lower() in {"1", "true", "yes"}
+
+        return cls(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            use_tls=use_tls,
+            from_address=from_address,
+            logger=logger,
+        )
+
+    def send_welcome_email(self, recipient, full_name):
+        subject = "Welcome to Bank of Anthos"
+        body = (
+            "Hi {name},\n\n"
+            "Welcome to Bank of Anthos. Your account has been created successfully.\n\n"
+            "If you did not sign up for this account, please contact support.\n"
+        ).format(name=full_name)
+        self._send_email(recipient, subject, body)
+
+    def send_password_reset_email(self, recipient, reset_link):
+        subject = "Reset your Bank of Anthos password"
+        body = (
+            "We received a request to reset your Bank of Anthos password.\n\n"
+            "To reset your password, visit the following link:\n"
+            "{link}\n\n"
+            "If you did not request a password reset, you can ignore this email.\n"
+        ).format(link=reset_link)
+        self._send_email(recipient, subject, body)
+
+    def _send_email(self, recipient, subject, body):
+        msg = EmailMessage()
+        msg["From"] = self._from_address
+        msg["To"] = recipient
+        msg["Subject"] = subject
+        msg.set_content(body)
+
+        self._logger.debug(
+            "SmtpNotificationProvider: sending email to %s via %s:%s",
+            recipient,
+            self._host,
+            self._port,
+        )
+
+        with smtplib.SMTP(self._host, self._port) as server:
+            if self._use_tls:
+                server.starttls()
+            if self._username:
+                server.login(self._username, self._password or "")
+            server.send_message(msg)
+
+        self._logger.info(
+            "SmtpNotificationProvider: email sent to %s with subject '%s'",
+            recipient,
+            subject,
+        )
+
+
+class NotificationsService:
+    """
+    Simple notifications service that delegates to a concrete provider.
+
+    The provider is selected using the NOTIFICATIONS_PROVIDER environment
+    variable. Supported values:
+      - "console" (default)
+      - "smtp"
+    """
+
+    def __init__(self, logger):
+        self._logger = logger
+        provider_name = os.getenv("NOTIFICATIONS_PROVIDER", "console").lower()
+
+        if provider_name == "smtp":
+            try:
+                self._provider = SmtpNotificationProvider.from_env(logger)
+                self._logger.info("NotificationsService: using SMTP provider")
+            except Exception as err:  # pylint: disable=broad-except
+                # If SMTP configuration is invalid, fall back to console provider
+                self._logger.error(
+                    "NotificationsService: failed to initialise SMTP provider (%s). "
+                    "Falling back to console provider.",
+                    err,
+                )
+                self._provider = ConsoleNotificationProvider(logger)
+        else:
+            self._logger.info("NotificationsService: using console provider")
+            self._provider = ConsoleNotificationProvider(logger)
+
+    def send_welcome_email(self, recipient, full_name):
+        try:
+            self._provider.send_welcome_email(recipient, full_name)
+        except Exception as err:  # pylint: disable=broad-except
+            # Email failures should not break core user flows.
+            self._logger.error(
+                "NotificationsService: error sending welcome email to %s: %s",
+                recipient,
+                err,
+            )
+
+    def send_password_reset_email(self, recipient, reset_link):
+        try:
+            self._provider.send_password_reset_email(recipient, reset_link)
+        except Exception as err:  # pylint: disable=broad-except
+            self._logger.error(
+                "NotificationsService: error sending password reset email to %s: %s",
+                recipient,
+                err,
+            )

--- a/src/accounts/userservice/tests/test_notifications.py
+++ b/src/accounts/userservice/tests/test_notifications.py
@@ -1,0 +1,120 @@
+# Copyright 2024
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for notification providers.
+"""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from userservice.notifications import (
+    ConsoleNotificationProvider,
+    SmtpNotificationProvider,
+)
+
+
+class TestConsoleNotificationProvider(unittest.TestCase):
+    """Tests for the console notification provider."""
+
+    def setUp(self):
+        self.logger = MagicMock()
+        self.provider = ConsoleNotificationProvider(self.logger)
+
+    def test_send_welcome_email_logs_message(self):
+        """Console provider should log welcome email details."""
+        self.provider.send_welcome_email("user@example.com", "Test User")
+
+        self.logger.info.assert_called_with(
+            "ConsoleNotificationProvider: welcome email to %s (%s)",
+            "user@example.com",
+            "Test User",
+        )
+
+    def test_send_password_reset_email_logs_message(self):
+        """Console provider should log reset email details."""
+        self.provider.send_password_reset_email("user@example.com", "https://reset")
+
+        self.logger.info.assert_called_with(
+            "ConsoleNotificationProvider: password reset email to %s with link %s",
+            "user@example.com",
+            "https://reset",
+        )
+
+
+class TestSmtpNotificationProvider(unittest.TestCase):
+    """Tests for the SMTP notification provider."""
+
+    def setUp(self):
+        # Ensure we start from a clean environment for each test
+        self.env_patcher = patch.dict(os.environ, {}, clear=True)
+        self.env_patcher.start()
+        self.logger = MagicMock()
+
+    def tearDown(self):
+        self.env_patcher.stop()
+
+    def test_from_env_requires_host_and_from_address(self):
+        """from_env should validate required configuration."""
+        with self.assertRaises(ValueError):
+            SmtpNotificationProvider.from_env(self.logger)
+
+        os.environ["SMTP_HOST"] = "smtp.example.com"
+        with self.assertRaises(ValueError):
+            SmtpNotificationProvider.from_env(self.logger)
+
+    @patch("userservice.notifications.smtplib.SMTP")
+    def test_send_welcome_email_uses_smtp(self, mock_smtp_cls):
+        """SMTP provider should send a welcome email using smtplib."""
+        os.environ["SMTP_HOST"] = "smtp.example.com"
+        os.environ["SMTP_FROM_ADDRESS"] = "no-reply@example.com"
+        os.environ["SMTP_PORT"] = "1025"
+        os.environ["SMTP_USERNAME"] = "user"
+        os.environ["SMTP_PASSWORD"] = "pass"
+        os.environ["SMTP_USE_TLS"] = "true"
+
+        provider = SmtpNotificationProvider.from_env(self.logger)
+
+        mock_smtp = MagicMock()
+        mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
+
+        provider.send_welcome_email("recipient@example.com", "Test User")
+
+        mock_smtp_cls.assert_called_with("smtp.example.com", 1025)
+        mock_smtp.starttls.assert_called_once()
+        mock_smtp.login.assert_called_once_with("user", "pass")
+        mock_smtp.send_message.assert_called_once()
+
+    @patch("userservice.notifications.smtplib.SMTP")
+    def test_send_password_reset_email_without_auth(self, mock_smtp_cls):
+        """SMTP provider should work without authentication if credentials are absent."""
+        os.environ["SMTP_HOST"] = "smtp.example.com"
+        os.environ["SMTP_FROM_ADDRESS"] = "no-reply@example.com"
+        os.environ["SMTP_PORT"] = "25"
+        os.environ["SMTP_USE_TLS"] = "false"
+
+        provider = SmtpNotificationProvider.from_env(self.logger)
+
+        mock_smtp = MagicMock()
+        mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
+
+        provider.send_password_reset_email(
+            "recipient@example.com", "https://reset-link"
+        )
+
+        mock_smtp_cls.assert_called_with("smtp.example.com", 25)
+        mock_smtp.starttls.assert_not_called()
+        mock_smtp.login.assert_not_called()
+        mock_smtp.send_message.assert_called_once()

--- a/src/accounts/userservice/userservice.py
+++ b/src/accounts/userservice/userservice.py
@@ -29,6 +29,8 @@ from flask import Flask, jsonify, request
 import bleach
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
+from notifications import NotificationsService
+
 from opentelemetry import trace
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace import TracerProvider
@@ -118,6 +120,12 @@ def create_app():
             app.logger.debug("Adding user to the database")
             users_db.add_user(user_data)
             app.logger.info("Successfully created user.")
+
+            # Send welcome notification. Failures here should not impact user creation.
+            notifications_service.send_welcome_email(
+                req["username"],
+                "{} {}".format(req["firstname"], req["lastname"])
+            )
 
         except UserWarning as warn:
             app.logger.error("Error creating new user: %s", str(warn))
@@ -246,6 +254,10 @@ def create_app():
     except OperationalError:
         app.logger.critical("users_db database connection failed")
         sys.exit(1)
+
+    # Configure notifications service
+    notifications_service = NotificationsService(app.logger)
+
     return app
 
 


### PR DESCRIPTION
Introduce a simple, pluggable notifications service to move all user-facing email sends (welcome and password reset) behind a provider abstraction. Two providers are implemented: a Console provider (default) and an SMTP provider. Provider selection is driven by environment variables, and the SMTP provider configuration is validated at startup. The user service now uses the notifications service to send welcome emails after user creation, without failing the core flow if notification delivery fails. Documentation and tests have been added to cover both providers and how to switch the provider.

Key changes:
- New notifications module (src/accounts/userservice/notifications.py)
  - Abstract NotificationProvider with concrete ConsoleNotificationProvider and SmtpNotificationProvider
  - SMTP provider configurable via environment variables (NOTIFICATIONS_PROVIDER, SMTP_HOST, SMTP_PORT, SMTP_USERNAME, SMTP_PASSWORD, SMTP_USE_TLS, SMTP_FROM_ADDRESS)
  - NotificationsService that selects the provider at runtime and gracefully falls back to the console provider on misconfiguration
  - Public methods: send_welcome_email and send_password_reset_email with robust error handling to avoid breaking user flows
- Wire-up in user service (src/accounts/userservice/userservice.py)
  - Import and instantiate NotificationsService
  - Send welcome email after user creation; errors are logged and do not affect the main flow
- Tests for providers (src/accounts/userservice/tests/test_notifications.py)
  - Tests for ConsoleNotificationProvider logging
  - Tests for SmtpNotificationProvider.from_env validation and SMTP usage (with and without auth), using mocks
- Documentation updates
  - README.md updated to reference new notifications provider configuration
  - src/accounts/userservice/README.md includes a new section detailing NOTIFICATIONS_PROVIDER, SMTP-related vars, and how to switch providers

Notes:
- Frontend behavior remains unchanged
- README guidance explains how to switch providers by updating NOTIFICATIONS_PROVIDER and redeploying
- All unit tests should pass with the new providers and wiring

---

> This pull request was co-created with Cosine Genie

Original Task: [finance-demo/3howx8azmwlx](https://cosine.sh/cosinedemo/finance-demo/task/3howx8azmwlx)
Author: Des Kramer
